### PR TITLE
add calc_measure function

### DIFF
--- a/calculate_measures/calculate_measures.py
+++ b/calculate_measures/calculate_measures.py
@@ -122,3 +122,72 @@ df['Measure13_check'] = calc_multi_measure(df,['s_sat_a_clr','s_sat_a_app','s_sa
 
 df['Measure16_check'] = calc_one_question_measure(df,'s_sat_tot','Measure16_check')
 '''
+
+
+def calc_measure(df, components=[], preserve_NA=True):
+    ''' 
+    Calculates a survey measure based on n-components.
+
+    Derives a binary value:
+    - 1: at least 1 positive outcome and no negative outcomes in any component
+    - 0: negative outcome in any component, regardless of any positive outcome
+    - NA: if all components are null/NA
+    
+    All values <1 or >5 assumed to be NA.
+
+    Args:
+        df (pandas dataframe): a dataframe with columns for each measure component
+        components (list): a list with the column names from df for each component
+        output_name (string): the desired name of the resulting series
+        preserve_NA (boolean): specifies whether to keep numerical NA values or replace with NaN
+
+    Returns:
+        A list the same length as the input dataframe with binary values. 
+    '''
+    # convert component argument to a list, if it is not already a list
+    # which may occur if component is a single column
+    if type(components) != type(list):
+        components = [components]
+
+    data = df[components].copy()
+
+    # replace NAs
+    if preserve_NA == False:
+        data.mask((data < 0) | (data > 5), np.nan, inplace=True)
+    else:
+        data.mask((data > 5), -999, inplace=True)
+
+    # make 5-point variables binary. 
+    # Can't just use np.where because the NaNs would be evaluated and get changed to 1 or 0.
+    data.replace(2, 1, inplace=True)
+    data.mask((data.isin([3, 4, 5])), 0, inplace=True)
+
+    # this logic is a bit backwards but very concise:
+    # make measure equal to 1 by default
+    data['measure'] = 1
+    # change rows with ANY 0 to 0 (doesn't matter whether the rest are null or 1)
+    # technically this is also 
+    data.loc[(data[components] == 0).any(1), 'measure'] = 0
+    # change rows will ALL null to NaN
+    if preserve_NA == False:
+        data.loc[data[components].isnull().all(1), 'measure'] = np.nan
+    else:
+        data.loc[(~data[components].isin([0,1])).all(1), 'measure'] = -999
+
+    return(data['measure'])
+
+# Test
+# data = pd.DataFrame({
+#     'component_1': [1, 2, 3, 4, 5, 5, -999],
+#     'component_2': [1, 1, 1, 1, 1, 4, 5]
+# })
+
+# calc_measure(df=data, components=['component_1'], preserve_NA=False)
+# calc_measure(df=data, components='component_1', preserve_NA=False) # This also works if single column provided is not in a list
+# calc_measure(df=data, components=['component_1', 'component_2'], preserve_NA=False)
+
+# # Assign the list to a column name
+# data['single'] = calc_measure(df=data, components=['component_1'], preserve_NA=False)
+# data['multi'] = calc_measure(df=data, components=['component_1', 'component_2'], preserve_NA=False)
+
+# data


### PR DESCRIPTION
This new function generalises Megan's two prototype functions (calc_multi_measure and calc_onee_question_measure), converting it to just a single function.

Note that the function can take on _n_ number of components, and that n = 1 should not be a special case that warrants a separate function.

The new function is also modified to return a list, rather than a named pandas series. This removed the need for a separate argument for output_name in the function, only then to assign it to a named column afterwards. 